### PR TITLE
Thêm chức năng quản lý người dùng cơ bản cho Admin

### DIFF
--- a/backend/admin
+++ b/backend/admin
@@ -1,0 +1,2 @@
+email: admin@wanderlog.com
+password: admin1

--- a/backend/prisma/migrations/20250814070620_create_admin_logs_table/migration.sql
+++ b/backend/prisma/migrations/20250814070620_create_admin_logs_table/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE `admin_logs` (
+    `id` VARCHAR(191) NOT NULL,
+    `admin_id` VARCHAR(191) NOT NULL,
+    `action` TEXT NOT NULL,
+    `target_id` VARCHAR(191) NOT NULL,
+    `target_type` VARCHAR(191) NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -166,3 +166,13 @@ model Comment {
   @@map("comment")
 }
 
+model AdminLog {
+  id        String   @id @default(cuid())
+  adminId   String   @map("admin_id")
+  action    String   @db.Text
+  targetId  String   @map("target_id")
+  targetType String   @map("target_type")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@map("admin_logs")
+}

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,0 +1,37 @@
+import { 
+  Controller,
+  Get, 
+  UseGuards, 
+  Param, 
+  Put,
+  Body,
+  Req  
+} from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from './admin.guard';
+import { UpdateUserStatusDto } from './dto/update-user-status.dto';
+import { Request } from 'express';
+import { JwtPayload } from './jwt-payload.type';
+@Controller('admin')
+@UseGuards(JwtAuthGuard, AdminGuard) 
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get('users') 
+  async getAllUsers() {
+    return this.adminService.findAllUsers();
+  }
+
+  @Put('users/:userId/status')
+  async updateUserStatus(
+    @Param('userId') userId: string,
+    @Body() updateUserStatusDto: UpdateUserStatusDto,
+    @Req() req: Request
+  ) {
+    const { isActive, reason } = updateUserStatusDto;
+    const admin = req.user as JwtPayload; 
+    const adminId = admin.id;
+    return this.adminService.updateUserStatus(adminId, userId, isActive, reason);
+  }
+}

--- a/backend/src/admin/admin.guard.ts
+++ b/backend/src/admin/admin.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
-import { I18nContext, I18nService } from 'nestjs-i18n';
+import { I18nService } from 'nestjs-i18n';
 
 @Injectable()
 export class AdminGuard implements CanActivate {
@@ -11,9 +11,7 @@ export class AdminGuard implements CanActivate {
 
     if (!user || user.role !== 'ADMIN') {
       throw new ForbiddenException(
-        this.i18n.t('auth.forbidden_access', { 
-          lang: I18nContext.current()?.lang 
-        })
+        this.i18n.t('auth.forbidden_access')
       );
     }
 

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { AdminController } from './admin.controller';
+import { MailsModule } from 'src/mails/mails.module';
+
+@Module({
+    imports: [
+    MailsModule,
+  ],
+  providers: [AdminService],
+  controllers: [AdminController]
+})
+export class AdminModule {}

--- a/backend/src/admin/dto/update-user-status.dto.ts
+++ b/backend/src/admin/dto/update-user-status.dto.ts
@@ -1,0 +1,10 @@
+import { IsBoolean, IsString, IsNotEmpty } from 'class-validator';
+
+export class UpdateUserStatusDto {
+  @IsBoolean()
+  isActive: boolean;
+
+  @IsString()
+  @IsNotEmpty()
+  reason: string;
+}

--- a/backend/src/admin/jwt-payload.type.ts
+++ b/backend/src/admin/jwt-payload.type.ts
@@ -1,0 +1,7 @@
+import { Role } from '@prisma/client';
+
+export interface JwtPayload {
+  id: string;
+  email: string;
+  role: Role;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,7 +22,7 @@ import { UsersService } from './users/users.service';
 import { UsersController } from './users/users.controller';
 import { UsersModule } from './users/users.module';
 import { InteractModule } from './interact/interact.module';
-
+import { AdminModule } from './admin/admin.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -44,6 +44,7 @@ import { InteractModule } from './interact/interact.module';
     ActivitiesModule,
     UsersModule,
     InteractModule,
+    AdminModule,
   ],
   controllers: [AppController, PostsController, UsersController],
   providers: [AppService, PostsService, UsersService],

--- a/backend/src/auth/admin.guard.ts
+++ b/backend/src/auth/admin.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { I18nContext, I18nService } from 'nestjs-i18n';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(private readonly i18n: I18nService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user; 
+
+    if (!user || user.role !== 'ADMIN') {
+      throw new ForbiddenException(
+        this.i18n.t('auth.forbidden_access', { 
+          lang: I18nContext.current()?.lang 
+        })
+      );
+    }
+
+    return true;
+  }
+}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -43,7 +43,7 @@ export class AuthService {
       data: { email, passwordHash, name },
     });
 
-    const payload = { sub: user.id, email: user.email };
+    const payload = { sub: user.id, email: user.email, role: user.role };
     const token = this.jwtService.sign(payload);
 
     return {
@@ -90,7 +90,7 @@ export class AuthService {
       );
     }
 
-    const payload = { sub: user.id, email: user.email };
+    const payload = { sub: user.id, email: user.email, role: user.role };
     const token = this.jwtService.sign(payload);
 
     return {
@@ -226,11 +226,12 @@ export class AuthService {
           name: oauthUser.name,
           avatar: oauthUser.avatar,
           authProvider: 'GOOGLE',
+          role: 'USER',
         },
       });
     }
 
-    const payload = { sub: user.id, email: user.email };
+    const payload = { sub: user.id, email: user.email, role: user.role };
     const token = this.jwtService.sign(payload);
 
     return {

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -2,22 +2,31 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { I18nService } from 'nestjs-i18n';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private prisma: PrismaService) {
+  constructor(
+    private prisma: PrismaService, 
+    private readonly i18n: I18nService,) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: process.env.JWT_SECRET || 'your-default-secret',
     });
   }
 
-  async validate(payload: { sub: string; email: string }) {
+  async validate(payload: { sub: string; email: string; role: string }) {
     const user = await this.prisma.user.findUnique({ where: { id: payload.sub } });
-    if (!user) {
-      throw new UnauthorizedException();
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException(
+        this.i18n.t('auth.account_disabled')
+      );
     }
-    const { passwordHash, ...userWithoutPassword } = user;
-    return userWithoutPassword; 
+    
+    return {
+      id: user.id,
+      email: user.email,
+      role: user.role,
+    };
   }
 }

--- a/backend/src/i18n/en/admin.json
+++ b/backend/src/i18n/en/admin.json
@@ -1,0 +1,3 @@
+{
+  "user_not_found": "Not found this user."
+}

--- a/backend/src/i18n/en/auth.json
+++ b/backend/src/i18n/en/auth.json
@@ -1,7 +1,7 @@
 {
   "email_exists": "Email already exists",
   "invalid_credentials": "Invalid email or password",
-  "account_disabled": "Account has been disabled",
+  "account_disabled": "User does not exist or account is disabled.",
   "signup_success": "Registration successful",
   "signin_success": "Login successful",
   "user_not_found": "User not found with this email",
@@ -17,5 +17,6 @@
   "reset_password_email_footer": "If you did not request a password reset, please ignore this email.",
   "reset_password_expiry": "This link will expire in 1 hour",
   "reset_password_security_title": "Security Notice",
-  "reset_password_security_content": "If you did not request a password reset, please contact us immediately. Do not share this link with anyone."
+  "reset_password_security_content": "If you did not request a password reset, please contact us immediately. Do not share this link with anyone.",
+  "forbidden_access": "You do not have permission to access this function."
 }

--- a/backend/src/i18n/en/mail.json
+++ b/backend/src/i18n/en/mail.json
@@ -1,0 +1,6 @@
+{
+  "account_activated_subject": "Your WanderLog account has been activated",
+  "account_deactivated_subject": "Your WanderLog account has been deactivated",
+  "status_activated_text": "activated",
+  "status_deactivated_text": "deactivated"
+}

--- a/backend/src/i18n/vi/admin.json
+++ b/backend/src/i18n/vi/admin.json
@@ -1,0 +1,3 @@
+{
+  "user_not_found": "Không tìm thấy người dùng."
+}

--- a/backend/src/i18n/vi/auth.json
+++ b/backend/src/i18n/vi/auth.json
@@ -1,7 +1,7 @@
 {
   "email_exists": "Email đã tồn tại",
   "invalid_credentials": "Email hoặc mật khẩu không đúng",
-  "account_disabled": "Tài khoản đã bị vô hiệu hóa",
+  "account_disabled": "Người dùng không tồn tại hoặc đã bị vô hiệu hóa.",
   "signup_success": "Đăng ký thành công",
   "signin_success": "Đăng nhập thành công",
   "user_not_found": "Không tìm thấy người dùng với email này",
@@ -17,5 +17,6 @@
   "reset_password_email_footer": "Nếu bạn không yêu cầu đặt lại mật khẩu, vui lòng bỏ qua email này.",
   "reset_password_expiry": "Link sẽ hết hạn sau 1 giờ",
   "reset_password_security_title": "Lưu ý bảo mật",
-  "reset_password_security_content": "Nếu bạn không yêu cầu đặt lại mật khẩu, vui lòng liên hệ với chúng tôi ngay lập tức. Không chia sẻ link này với bất kỳ ai."
+  "reset_password_security_content": "Nếu bạn không yêu cầu đặt lại mật khẩu, vui lòng liên hệ với chúng tôi ngay lập tức. Không chia sẻ link này với bất kỳ ai.",
+  "forbidden_access": "Bạn không có quyền truy cập chức năng này."
 }

--- a/backend/src/i18n/vi/mail.json
+++ b/backend/src/i18n/vi/mail.json
@@ -1,0 +1,6 @@
+{
+  "account_activated_subject": "Tài khoản WanderLog của bạn đã được kích hoạt",
+  "account_deactivated_subject": "Tài khoản WanderLog của bạn đã bị vô hiệu hóa",
+  "status_activated_text": "kích hoạt",
+  "status_deactivated_text": "vô hiệu hóa"
+}

--- a/backend/src/mails/mails.service.ts
+++ b/backend/src/mails/mails.service.ts
@@ -2,12 +2,14 @@ import { Injectable } from '@nestjs/common';
 import * as path from 'path';
 import { ConfigService } from '@nestjs/config';
 import { MailerService } from 'src/mailer/mailer.service';
+import { I18nService } from 'nestjs-i18n';
 
 @Injectable()
 export class MailsService {
   constructor(
     private readonly mailerService: MailerService,
     private readonly configService: ConfigService,
+    private readonly i18n: I18nService, 
   ) {}
 
   async forgotPassword(mailData: {
@@ -32,6 +34,45 @@ export class MailsService {
       context: {
         username: mailData.data.user_name,
         resetLink: `${this.configService.get<string>('app.clientURL') || 'http://localhost:3001'}/reset-password?token=${mailData.data.token}`,
+      },
+    });
+  }
+  async sendUserStatusUpdate(mailData: {
+    to: string;
+    data: {
+      user_name: string;
+      new_status: 'activated' | 'deactivated'; 
+      reason?: string; 
+    };
+  }): Promise<void> {
+    const subject = this.i18n.t(
+      mailData.data.new_status === 'activated'
+        ? 'mail.account_activated_subject'
+        : 'mail.account_deactivated_subject'
+    );
+
+    const newStatusText = this.i18n.t(
+      mailData.data.new_status === 'activated'
+        ? 'mail.status_activated_text'
+        : 'mail.status_deactivated_text'
+    );
+
+    await this.mailerService.sendMail({
+      to: mailData.to,
+      subject: subject,
+      templatePath: path.join(
+        this.configService.get<string>('mailer.workingDirectory', {
+          infer: true,
+        }) || process.cwd(),
+        'src',
+        'mails',
+        'templates',
+        'user-status-update.hbs', 
+      ),
+      context: {
+        username: mailData.data.user_name,
+        new_status_text: newStatusText, 
+        reason: mailData.data.reason,
       },
     });
   }

--- a/backend/src/mails/templates/user-status-update.hbs
+++ b/backend/src/mails/templates/user-status-update.hbs
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Thông báo cập nhật trạng thái tài khoản của bạn</title>
+    <title>Your Account Status Update Notification</title>
 </head>
 <body>
-    <h1>Cập nhật trạng thái tài khoản</h1>
-    <p>Xin chào {{username}},</p>
+    <h1>Account Status Update</h1>
+    <p>Hello {{username}},</p>
     
-    <p>Tài khoản của bạn trên WanderLog đã được <strong>{{new_status_text}}</strong>.</p>
+    <p>The status of your WanderLog account has been <strong>{{new_status_text}}</strong>.</p>
     
     {{#if reason}}
-    <p>Lý do: {{reason}}</p>
+    <p>Reason: {{reason}}</p>
     {{/if}}
 
-    <p>Nếu bạn có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi.</p>
+    <p>If you have any questions, please contact us.</p>
     
-    <p>Trân trọng,</p>
-    <p>Đội ngũ WanderLog</p>
+    <p>Sincerely, </p>
+    <p>The WanderLog Team</p>
 </body>
 </html>

--- a/backend/src/mails/templates/user-status-update.hbs
+++ b/backend/src/mails/templates/user-status-update.hbs
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Thông báo cập nhật trạng thái tài khoản của bạn</title>
+</head>
+<body>
+    <h1>Cập nhật trạng thái tài khoản</h1>
+    <p>Xin chào {{username}},</p>
+    
+    <p>Tài khoản của bạn trên WanderLog đã được <strong>{{new_status_text}}</strong>.</p>
+    
+    {{#if reason}}
+    <p>Lý do: {{reason}}</p>
+    {{/if}}
+
+    <p>Nếu bạn có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi.</p>
+    
+    <p>Trân trọng,</p>
+    <p>Đội ngũ WanderLog</p>
+</body>
+</html>


### PR DESCRIPTION
PR này giới thiệu các thay đổi ban đầu để xây dựng bảng điều khiển dành cho Admin. Các chức năng chính bao gồm:

Các tính năng đã triển khai:

API Đăng nhập Admin:
Endpoint: POST /api/auth/signin 
Mô tả: Cho phép người dùng với vai trò ADMIN đăng nhập và nhận về một JWT token.

API Quản lý Người dùng:
Endpoint: GET /api/admin/users 
Mô tả: Lấy danh sách tất cả người dùng trong hệ thống. Chỉ dành cho Admin.


Endpoint: PUT /api/admin/users/:userId/status 
Mô tả: Cập nhật trạng thái isActive của một người dùng, cho phép Admin vô hiệu hóa hoặc kích hoạt tài khoản.
Ghi log Hành động:
Đã thêm logic để ghi lại các hành động của Admin (ví dụ: cập nhật trạng thái người dùng) vào bảng 
admin_logs để dễ dàng truy vết.

Thông báo qua Email:
Đã cập nhật dịch vụ gửi mail để tự động gửi email thông báo cho người dùng khi trạng thái tài khoản của họ bị thay đổi.

Bảo mật:
Đã tạo AdminGuard để bảo vệ các route admin, đảm bảo chỉ những người dùng có vai trò ADMIN mới có quyền truy cập.

Các tính năng Admin cần làm tiếp theo:

Quản lý nội dung:
Endpoint: GET /api/admin/itineraries 
Mô tả: Lấy danh sách các lịch trình để kiểm duyệt.
Endpoint: DELETE /api/admin/users/:userId 
Mô tả: Xóa tài khoản người dùng.
Thống kê:
Endpoint: GET /api/admin/dashboard 
Mô tả: Cung cấp số liệu thống kê về số lượng lịch trình được tạo theo tuần, tháng, năm.